### PR TITLE
Only looking up once instead of multiple times

### DIFF
--- a/ATL/AudioData/Utils/FileStructureHelper.cs
+++ b/ATL/AudioData/Utils/FileStructureHelper.cs
@@ -498,7 +498,6 @@ namespace ATL.AudioData
 
 
             if (null == zones) return false;
-            //if (!zones.ContainsKey(zone)) return true; // No effect
             if (zones.TryGetValue(zone, out var currentZone))
             {
                 return true;

--- a/ATL/AudioData/Utils/FileStructureHelper.cs
+++ b/ATL/AudioData/Utils/FileStructureHelper.cs
@@ -498,7 +498,11 @@ namespace ATL.AudioData
 
 
             if (null == zones) return false;
-            if (!zones.ContainsKey(zone)) return true; // No effect
+            //if (!zones.ContainsKey(zone)) return true; // No effect
+            if (zones.TryGetValue(zone, out var currentZone))
+            {
+                return true;
+            }
 
 
             // Get the dynamic correction map from the proper region
@@ -512,7 +516,7 @@ namespace ATL.AudioData
             bool isPostReprocessing = zone == POST_PROCESSING_ZONE_NAME;
 
             // == Update the current zone's headers
-            foreach (FrameHeader header in zones[zone].Headers)
+            foreach (FrameHeader header in currentZone.Headers)
             {
                 // === Update values
                 offsetPositionCorrection = -globalOffsetCorrection;
@@ -631,7 +635,7 @@ namespace ATL.AudioData
 
             // Update local dynamic offset
             if (!localDynamicOffsetCorrection.ContainsKey(zone))
-                localDynamicOffsetCorrection.Add(zone, new KeyValuePair<long, long>(zones[zone].Offset + zones[zone].Size, deltaSize));
+                localDynamicOffsetCorrection.Add(zone, new KeyValuePair<long, long>(currentZone.Offset + currentZone.Size, deltaSize));
 
             // If applicable, update global dynamic offset
             if (regionId > -1)
@@ -639,7 +643,7 @@ namespace ATL.AudioData
                 IDictionary<string, KeyValuePair<long, long>> globalRegion = dynamicOffsetCorrection[-1];
                 // Add new region
                 if (!globalRegion.ContainsKey(zone))
-                    globalRegion.Add(zone, new KeyValuePair<long, long>(zones[zone].Offset + zones[zone].Size, deltaSize));
+                    globalRegion.Add(zone, new KeyValuePair<long, long>(currentZone.Offset + currentZone.Size, deltaSize));
                 else // Increment current delta to existing region
                 {
                     KeyValuePair<long, long> currentValues = globalRegion[zone];


### PR DESCRIPTION
fixes #122 
This fix reduces save time from 5+ minutes down to less than 1 sec

I suppose thats because:

- The dictionary is not local to the function (it has to be retreived from the heap each time)
- Dictionaries aren't free
- Lookup times still go up, when its bigger (my case: 80k)
- There is a lookup each iteration (see attachments)


![image](https://user-images.githubusercontent.com/11245306/148312966-b821297b-5e9d-4c7a-bfd0-8a290634bc4d.png)

Now, please give me my cookie, i deserved it!


Before:
![image](https://user-images.githubusercontent.com/11245306/148314656-4c611155-ae19-45ed-8431-e4d0c02eb152.png)


After:
![image](https://user-images.githubusercontent.com/11245306/148313250-bace7f7e-dd43-448e-b9fb-be204feab87e.png)

