### PR TITLE
Fixed #131: failing unit tests on linux and unix systems

### DIFF
--- a/ATL.test/Playlist/ASXIO.cs
+++ b/ATL.test/Playlist/ASXIO.cs
@@ -13,17 +13,25 @@ namespace ATL.test.IO.Playlist
         [TestMethod]
         public void PLIO_R_ASX()
         {
-            string testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist.asx", "$PATH", TestUtils.GetResourceLocationRoot(false).Replace("\\", "/"));
-
+            var testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist.asx", "$PATH", TestUtils.GetResourceLocationRoot(false).Replace("\\", "/"));
+            
             try
             {
-
-                IPlaylistIO theReader = PlaylistIOFactory.GetInstance().GetPlaylistIO(testFileLocation);
-
+                var theReader = PlaylistIOFactory.GetInstance().GetPlaylistIO(testFileLocation);
+                var filePaths = theReader.FilePaths;
+                var tracks = theReader.Tracks;
+                
                 Assert.IsNotInstanceOfType(theReader, typeof(ATL.Playlist.IO.DummyIO));
-                Assert.AreEqual(4, theReader.FilePaths.Count);
-                foreach (string s in theReader.FilePaths) Assert.IsTrue(System.IO.File.Exists(s));
-                foreach (Track t in theReader.Tracks) Assert.IsTrue(t.Duration > 0);
+                Assert.AreEqual(4, filePaths.Count);
+                foreach (var s in filePaths)
+                {
+                    Assert.IsTrue(System.IO.File.Exists(s));
+                }
+
+                foreach (var t in tracks)
+                {
+                    Assert.IsTrue(t.Duration > 0);
+                }
             }
             finally
             {
@@ -39,8 +47,8 @@ namespace ATL.test.IO.Playlist
             pathsToWrite.Add(TestUtils.GetResourceLocationRoot() + "bbb.mp3");
 
             IList<Track> tracksToWrite = new List<Track>();
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MP3\\empty.mp3"));
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MOD\\mod.mod"));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MP3","empty.mp3")));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MOD","mod.mod")));
 
 
             string testFileLocation = TestUtils.CreateTempTestFile("test.asx");

--- a/ATL.test/Playlist/B4SIO.cs
+++ b/ATL.test/Playlist/B4SIO.cs
@@ -13,16 +13,17 @@ namespace ATL.test.IO.Playlist
         [TestMethod]
         public void PLIO_R_B4S()
         {
-            string testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist.b4s", "$PATH", TestUtils.GetResourceLocationRoot(false));
-
+            var testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist.b4s", "$PATH", TestUtils.GetResourceLocationRoot(false));
+            
             try
             {
-                IPlaylistIO theReader = PlaylistIOFactory.GetInstance().GetPlaylistIO(testFileLocation);
-
+                var theReader = PlaylistIOFactory.GetInstance().GetPlaylistIO(testFileLocation);
+                var filePaths = theReader.FilePaths;
+                var tracks = theReader.Tracks;
                 Assert.IsNotInstanceOfType(theReader, typeof(ATL.Playlist.IO.DummyIO));
-                Assert.AreEqual(3, theReader.FilePaths.Count);
-                foreach (string s in theReader.FilePaths) Assert.IsTrue(System.IO.File.Exists(s));
-                foreach (Track t in theReader.Tracks) Assert.IsTrue(t.Duration > 0);
+                Assert.AreEqual(3, filePaths.Count);
+                foreach (var s in filePaths) Assert.IsTrue(System.IO.File.Exists(s));
+                foreach (var t in tracks) Assert.IsTrue(t.Duration > 0);
             }
             finally
             {
@@ -38,8 +39,8 @@ namespace ATL.test.IO.Playlist
             pathsToWrite.Add("bbb.mp3");
 
             IList<Track> tracksToWrite = new List<Track>();
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MP3\\empty.mp3"));
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MOD\\mod.mod"));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MP3","empty.mp3")));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MOD","mod.mod")));
 
 
             string testFileLocation = TestUtils.CreateTempTestFile("test.b4s");

--- a/ATL.test/Playlist/M3UIO.cs
+++ b/ATL.test/Playlist/M3UIO.cs
@@ -11,27 +11,33 @@ namespace ATL.test.IO.Playlist
         [TestMethod]
         public void PLIO_R_M3U()
         {
-            IPlaylistIO pls = PlaylistIOFactory.GetInstance().GetPlaylistIO(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist_simple.m3u");
-
+            var pls = PlaylistIOFactory.GetInstance().GetPlaylistIO(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist_simple.m3u");
+            
             Assert.IsNotInstanceOfType(pls, typeof(ATL.Playlist.IO.DummyIO));
             Assert.AreEqual(1, pls.FilePaths.Count);
-            foreach (string s in pls.FilePaths) Assert.IsTrue(System.IO.File.Exists(s));
-            foreach (Track t in pls.Tracks) Assert.IsTrue(t.Duration > 0); // Ensures the track has been parsed
+            foreach (var s in pls.FilePaths) Assert.IsTrue(System.IO.File.Exists(s));
+            foreach (var t in pls.Tracks) Assert.IsTrue(t.Duration > 0); // Ensures the track has been parsed
 
-            IList<KeyValuePair<string, string>> replacements = new List<KeyValuePair<string, string>>();
-            string resourceRoot = TestUtils.GetResourceLocationRoot(false);
+            var replacements = new List<KeyValuePair<string, string>>();
+            var resourceRoot = TestUtils.GetResourceLocationRoot(false);
             replacements.Add(new KeyValuePair<string, string>("$PATH", resourceRoot));
-            replacements.Add(new KeyValuePair<string, string>("$NODISK_PATH", resourceRoot.Substring(2, resourceRoot.Length - 2)));
-
-            string testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist_fullPath.m3u", replacements);
+            
+            // No disk path => on Windows this skips drive name, e.g. "C:" (not required on *nix)
+            var noDiskPath = Path.DirectorySeparatorChar != '\\'
+                ? resourceRoot
+                : resourceRoot.Substring(2, resourceRoot.Length - 2);
+            
+            replacements.Add(new KeyValuePair<string, string>("$NODISK_PATH", noDiskPath));
+            
+            var testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist_fullPath.m3u", replacements);
             try
             {
                 pls = PlaylistIOFactory.GetInstance().GetPlaylistIO(testFileLocation);
 
                 Assert.IsNotInstanceOfType(pls, typeof(ATL.Playlist.IO.DummyIO));
                 Assert.AreEqual(3, pls.FilePaths.Count);
-                foreach (string s in pls.FilePaths) Assert.IsTrue(System.IO.File.Exists(s));
-                foreach (Track t in pls.Tracks) Assert.IsTrue(t.Duration > 0); // Ensures the track has been parsed
+                foreach (var s in pls.FilePaths) Assert.IsTrue(File.Exists(s));
+                foreach (var t in pls.Tracks) Assert.IsTrue(t.Duration > 0); // Ensures the track has been parsed
             }
             finally
             {
@@ -94,8 +100,8 @@ namespace ATL.test.IO.Playlist
             pathsToWrite.Add("bbb.mp3");
 
             IList<Track> tracksToWrite = new List<Track>();
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MP3\\empty.mp3"));
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MOD\\mod.mod"));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MP3","empty.mp3")));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MOD","mod.mod")));
 
 
             string testFileLocation = TestUtils.CreateTempTestFile("test.m3u");

--- a/ATL.test/Playlist/PLSIO.cs
+++ b/ATL.test/Playlist/PLSIO.cs
@@ -36,8 +36,8 @@ namespace ATL.test.IO.Playlist
             pathsToWrite.Add("bbb.mp3");
 
             IList<Track> tracksToWrite = new List<Track>();
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MP3\\empty.mp3"));
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MOD\\mod.mod"));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MP3","empty.mp3")));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MOD","mod.mod")));
 
 
             string testFileLocation = TestUtils.CreateTempTestFile("test.pls");

--- a/ATL.test/Playlist/PlaylistIOTest.cs
+++ b/ATL.test/Playlist/PlaylistIOTest.cs
@@ -85,16 +85,23 @@ namespace ATL.test.IO.Playlist
         {
             IPlaylistIO theReader = PlaylistIOFactory.GetInstance().GetPlaylistIO(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist_simple.m3u");
 
-            Assert.AreEqual(1, theReader.FilePaths.Count);
-            foreach (string s in theReader.FilePaths)
+            var filePaths = theReader.FilePaths;
+            Assert.AreEqual(1, filePaths.Count);
+            foreach (string s in filePaths)
             {
                 Assert.IsTrue(System.IO.File.Exists(s));
             }
 
-            IList<KeyValuePair<string, string>> replacements = new List<KeyValuePair<string, string>>();
-            string resourceRoot = TestUtils.GetResourceLocationRoot(false);
+            var replacements = new List<KeyValuePair<string, string>>();
+            var resourceRoot = TestUtils.GetResourceLocationRoot(false);
             replacements.Add(new KeyValuePair<string, string>("$PATH", resourceRoot));
-            replacements.Add(new KeyValuePair<string, string>("$NODISK_PATH", resourceRoot.Substring(2, resourceRoot.Length - 2)));
+            
+            // No disk path => on Windows this skips drive name, e.g. "C:" (not required on *nix)
+            var noDiskPath = Path.DirectorySeparatorChar != '\\'
+                ? resourceRoot
+                : resourceRoot.Substring(2, resourceRoot.Length - 2);
+
+            replacements.Add(new KeyValuePair<string, string>("$NODISK_PATH", noDiskPath));
 
             string testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist_fullPath.m3u", replacements);
             try
@@ -131,10 +138,16 @@ namespace ATL.test.IO.Playlist
         [TestMethod]
         public void PL_SMIL()
         {
-            IList<KeyValuePair<string, string>> replacements = new List<KeyValuePair<string, string>>();
-            string resourceRoot = TestUtils.GetResourceLocationRoot(false);
+            var replacements = new List<KeyValuePair<string, string>>();
+            var resourceRoot = TestUtils.GetResourceLocationRoot(false);
             replacements.Add(new KeyValuePair<string, string>("$PATH", resourceRoot));
-            replacements.Add(new KeyValuePair<string, string>("$NODISK_PATH", resourceRoot.Substring(2, resourceRoot.Length - 2)));
+            
+            // No disk path => on Windows this skips drive name, e.g. "C:" (not required on *nix)
+            var noDiskPath = Path.DirectorySeparatorChar != '\\'
+                ? resourceRoot
+                : resourceRoot.Substring(2, resourceRoot.Length - 2);
+
+            replacements.Add(new KeyValuePair<string, string>("$NODISK_PATH", noDiskPath));
 
             string testFileLocation = TestUtils.CopyFileAndReplace(TestUtils.GetResourceLocationRoot() + "_Playlists/playlist.smil", replacements);
             try

--- a/ATL.test/Playlist/XSPFIO.cs
+++ b/ATL.test/Playlist/XSPFIO.cs
@@ -38,8 +38,8 @@ namespace ATL.test.IO.Playlist
             pathsToWrite.Add(TestUtils.GetResourceLocationRoot() + "bbb.mp3");
 
             IList<Track> tracksToWrite = new List<Track>();
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MP3\\empty.mp3"));
-            tracksToWrite.Add(new Track(TestUtils.GetResourceLocationRoot() + "MOD\\mod.mod"));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MP3","empty.mp3")));
+            tracksToWrite.Add(new Track(Path.Combine(TestUtils.GetResourceLocationRoot() + "MOD","mod.mod")));
 
 
             string testFileLocation = TestUtils.CreateTempTestFile("test.xspf");
@@ -73,7 +73,11 @@ namespace ATL.test.IO.Playlist
                                     parents.Add(source.Name);
                                     index++;
                                 }
-                                else if (source.Name.Equals("location", StringComparison.OrdinalIgnoreCase) && parents.Contains("track")) Assert.AreEqual(pathsToWrite[index], getXmlValue(source).Replace('/', '\\'));
+                                else if (source.Name.Equals("location", StringComparison.OrdinalIgnoreCase) &&
+                                         parents.Contains("track"))
+                                {
+                                    Assert.AreEqual(pathsToWrite[index], getXmlValue(source).Replace('/', System.IO.Path.DirectorySeparatorChar));
+                                }
                             }
                         }
                     }

--- a/ATL.test/TestUtils.cs
+++ b/ATL.test/TestUtils.cs
@@ -77,7 +77,7 @@ namespace ATL.test
                 {
                     replacedLine = line;
                     foreach (KeyValuePair<string, string> kvp in replacements) replacedLine = replacedLine.Replace(kvp.Key, kvp.Value);
-                    s.WriteLine(replacedLine);
+                    s.WriteLine(replacedLine.Replace("file:////", "file:///"));
                 }
             }
 

--- a/ATL/Playlist/PlaylistIO.cs
+++ b/ATL/Playlist/PlaylistIO.cs
@@ -18,10 +18,12 @@ namespace ATL.Playlist
         /// Byte Order Mark of UTF-8 files
         /// </summary>
         public static readonly byte[] BOM_UTF8 = new byte[] { 0xEF, 0xBB, 0xBF };
+
         /// <summary>
         /// .NET Encoding for UTF-8 with no Byte Order Mark
         /// </summary>
         protected static readonly Encoding UTF8_NO_BOM = new UTF8Encoding(false);
+
         /// <summary>
         /// Latin-1 encoding used as ANSI
         /// </summary>
@@ -31,10 +33,12 @@ namespace ATL.Playlist
         /// File Path of the playlist file
         /// </summary>
         public string Path { get; set; }
+
         /// <summary>
         /// Formatting of the track locations (file paths) within the playlist
         /// </summary>
         public PlaylistFormat.LocationFormatting LocationFormatting { get; set; }
+
         /// <summary>
         /// String encoding used within the playlist file
         /// </summary>
@@ -64,7 +68,7 @@ namespace ATL.Playlist
         /// </summary>
         /// <param name="fs">FileStream to use to read the values</param>
         /// <param name="result">List that will receive the values</param>
-        abstract protected void getFiles(FileStream fs, IList<string> result);
+        protected abstract void getFiles(FileStream fs, IList<string> result);
 
         /// <summary>
         /// Read the tracks described by the playlist using the given Stream
@@ -72,7 +76,7 @@ namespace ATL.Playlist
         /// </summary>
         /// <param name="fs">FileStream to use to read the tracks</param>
         /// <param name="result">List that will receive the tracks</param>
-        abstract protected void setTracks(FileStream fs, IList<Track> result);
+        protected abstract void setTracks(FileStream fs, IList<Track> result);
 
         /// <summary>
         /// Read the paths of the track files described by the playlist
@@ -180,6 +184,7 @@ namespace ATL.Playlist
                     settings.Encoding = UTF8_NO_BOM;
                     break;
             }
+
             settings.OmitXmlDeclaration = true;
             settings.ConformanceLevel = ConformanceLevel.Fragment;
             settings.Indent = true;
@@ -229,23 +234,24 @@ namespace ATL.Playlist
         protected string decodeLocation(string href)
         {
             // It it an URI ?
-            string hrefUri = href.Replace('\\', '/'); // Try and replace all \'s by /'s to detect URIs even if the location has been badly formatted
+            // Try and replace all \'s by /'s to detect URIs even if the location has been badly formatted
+            var hrefUri = href.Replace('\\', '/'); 
             if (hrefUri.Contains("://")) // RFC URI
             {
                 try
                 {
-                    Uri uri = new Uri(hrefUri);
+                    var uri = new Uri(hrefUri);
                     if (uri.IsFile)
                     {
                         if (!System.IO.Path.IsPathRooted(uri.LocalPath))
                         {
                             return System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Path), uri.LocalPath);
                         }
-                        else
-                        {
-                            // Hack to avoid paths being rooted by a double '\', thus making them unreadable by System.IO.Path
-                            return uri.LocalPath.Replace("" + System.IO.Path.DirectorySeparatorChar + System.IO.Path.DirectorySeparatorChar, "" + System.IO.Path.DirectorySeparatorChar);
-                        }
+                        
+                        // Hack to avoid paths being rooted by a double '\', thus making them unreadable by System.IO.Path
+                        return uri.LocalPath.Replace(
+                            "" + System.IO.Path.DirectorySeparatorChar + System.IO.Path.DirectorySeparatorChar,
+                            "" + System.IO.Path.DirectorySeparatorChar);
                     }
                 }
                 catch (UriFormatException)
@@ -254,7 +260,7 @@ namespace ATL.Playlist
                 }
             }
 
-            href = href.Replace("file:///", "").Replace("file://", "").Replace("file:", "");
+            href = href.Replace("file:///", "").Replace("file://", "").Replace("file:", "").Replace('\\', System.IO.Path.DirectorySeparatorChar);
             if (!System.IO.Path.IsPathRooted(href))
             {
                 href = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Path), href);


### PR DESCRIPTION
Following fixes for #131:

- replaced usages of `\\` directory separator with generic approach
- added special handling for `C:` drive names on windows
- replaced type initializers with `var` where changes have been made

Further analysis:
- Path handing is pretty likely to fail on edge cases, I would like to suggest using `Path` and `Uri` classes instead of strings where possible
- The [hack](https://github.com/Zeugma440/atldotnet/blob/f26d926ee2926f89cc934f4fc179b8feff9df709/ATL/Playlist/PlaylistIO.cs#L246) to handle UNC Paths is very strange - I would suggest having a better path handling here, as an example see a go path handler function i developed below:

```go
func normalizeLongPath(path string) string {
	// get absolute path - len(path) is not reliable for early return
	absolutePath, err := filepath.Abs(path)

	// fallback to default behaviour on error
	if err != nil {
		return path
	}

	// path is already normalized
	if strings.HasPrefix(absolutePath, `\\?\`) {
		return absolutePath
	}

	// normalize "network path"
	if strings.HasPrefix(absolutePath, `\\`) {
		return `\\?\UNC\` + strings.TrimPrefix(absolutePath, `\\`)
	}

	// normalize "local path"
	return `\\?\` + absolutePath
}
```