### PR TITLE
Fix typo in file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ MusePack / MPEGplus|.MPC, .MP+|R/W|R/W|R/W| |
 Noisetracker/Soundtracker/Protracker|.MOD| | | |R/W (2)|
 OGG : Vorbis, Opus, Embedded FLAC|.OGG, .OGA, .OPUS| | | |R/W|
 OptimFROG|.OFR, .OFS|R/W|R/W|R/W| |
-Portable  Sound Format|.PSF, .PSF1, .PSF2, .MINIPSF, .MINIPSF1, .MINIPSF2, .SSF, .MINISSF, .DSF, .MINIDSF, .GSF, .MINIGSF, .QSF, .MINISQF| | | |R/W|
+Portable  Sound Format|.PSF, .PSF1, .PSF2, .MINIPSF, .MINIPSF1, .MINIPSF2, .SSF, .MINISSF, .DSF, .MINIDSF, .GSF, .MINIGSF, .QSF, .MINIQSF| | | |R/W|
 ScreamTracker|.S3M| | | |R/W (2)|
 SPC700 (Super Nintendo Sound files)|.SPC| | | |R/W|
 Toms' losslesss Audio Kompressor|.TAK| | |R/W| |


### PR DESCRIPTION
There was a typo in the readme with the QSF file format.