### PR TITLE
Improve mapping between WAV and ATL frame codes

### DIFF
--- a/ATL/AudioData/IO/WAV.cs
+++ b/ATL/AudioData/IO/WAV.cs
@@ -80,12 +80,15 @@ namespace ATL.AudioData.IO
             { "info.INAM", Field.TITLE },
             { "info.TITL", Field.TITLE },
             { "info.IART", Field.ARTIST },
+            { "info.IPRD", Field.ALBUM },
             { "info.ICMT", Field.COMMENT },
             { "info.ICOP", Field.COPYRIGHT },
             { "info.ICRD", Field.RECORDING_DATE },
             { "info.IGNR", Field.GENRE },
             { "info.IRTD", Field.RATING },
-            { "info.TRCK", Field.TRACK_NUMBER }
+            { "info.TRCK", Field.TRACK_NUMBER },
+            { "info.IPRT", Field.TRACK_NUMBER },
+            { "info.ITRK", Field.TRACK_NUMBER }
         };
 
 


### PR DESCRIPTION
In WAV files encoded with ffmpeg album and track number are saved to IPRD and IPRT respectively. I tried to find some information to figure out what else can be used in WAV, and found that track number can be saved to ITRK, so I added this too.