### PR TITLE
LyricsPhrase - Fix NullReferenceException

### DIFF
--- a/ATL/ATL.csproj
+++ b/ATL/ATL.csproj
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;</TargetFrameworks>
     <Description>Fully managed, portable and easy-to-use C# library to read and edit audio data and metadata (tags) from various audio formats, playlists and CUE sheets</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Company />

--- a/ATL/ATL.csproj
+++ b/ATL/ATL.csproj
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.1</TargetFrameworks>
     <Description>Fully managed, portable and easy-to-use C# library to read and edit audio data and metadata (tags) from various audio formats, playlists and CUE sheets</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Company />

--- a/ATL/Entities/LyricsInfo.cs
+++ b/ATL/Entities/LyricsInfo.cs
@@ -158,7 +158,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a == b, else false</returns>
-            public static bool operator ==(LyricsPhrase a, LyricsPhrase b) => a.Equals(b);
+            public static bool operator ==(LyricsPhrase a, LyricsPhrase b) => a != null && a.Equals(b);
 
             /// <summary>
             /// Compares two LyricsPhrase objects by not-equals
@@ -166,7 +166,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a != b, else false</returns>
-            public static bool operator !=(LyricsPhrase a, LyricsPhrase b) => !a.Equals(b);
+            public static bool operator !=(LyricsPhrase a, LyricsPhrase b) => a != null && !a.Equals(b);
 
             /// <summary>
             /// Compares two LyricsPhrase objects by inferior
@@ -174,7 +174,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is greater than b, else false</returns>
-            public static bool operator <(LyricsPhrase a, LyricsPhrase b) => a.TimestampMs < b.TimestampMs && a.Text.CompareTo(b.Text) < 0;
+            public static bool operator <(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs < b.TimestampMs && a.Text.CompareTo(b.Text) < 0;
 
             /// <summary>
             /// Compares two LyricsPhrase objects by superior
@@ -182,7 +182,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is less than b, else false</returns>
-            public static bool operator >(LyricsPhrase a, LyricsPhrase b) => a.TimestampMs > b.TimestampMs && a.Text.CompareTo(b.Text) > 0;
+            public static bool operator >(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs > b.TimestampMs && a.Text.CompareTo(b.Text) > 0;
 
             /// <summary>
             /// Compares two LyricsPhrase objects by inferior-or-equals
@@ -190,7 +190,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is greater than b, else false</returns>
-            public static bool operator <=(LyricsPhrase a, LyricsPhrase b) => a.TimestampMs <= b.TimestampMs && a.Text.CompareTo(b.Text) <= 0;
+            public static bool operator <=(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs <= b.TimestampMs && a.Text.CompareTo(b.Text) <= 0;
 
             /// <summary>
             /// Compares two LyricsPhrase objects by superior-or-equals
@@ -198,7 +198,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is less than b, else false</returns>
-            public static bool operator >=(LyricsPhrase a, LyricsPhrase b) => a.TimestampMs >= b.TimestampMs && a.Text.CompareTo(b.Text) >= 0;
+            public static bool operator >=(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs >= b.TimestampMs && a.Text.CompareTo(b.Text) >= 0;
         }
 
         /// <summary>

--- a/ATL/Entities/LyricsInfo.cs
+++ b/ATL/Entities/LyricsInfo.cs
@@ -110,10 +110,6 @@ namespace ATL
             /// <exception cref="NullReferenceException">Thrown if other is null</exception>
             public int CompareTo(LyricsPhrase other)
             {
-                if (other == null)
-                {
-                    throw new NullReferenceException();
-                }
                 if (this < other)
                 {
                     return -1;

--- a/ATL/Entities/LyricsInfo.cs
+++ b/ATL/Entities/LyricsInfo.cs
@@ -144,7 +144,14 @@ namespace ATL
             /// </summary>
             /// <param name="toCompare">The LyricsPhrase object to compare</param>
             /// <returns>True if equals, else false</returns>
-            public bool Equals(LyricsPhrase toCompare) => toCompare != null && TimestampMs == toCompare.TimestampMs && Text == toCompare.Text;
+            public bool Equals(LyricsPhrase toCompare)
+            {
+                if (toCompare is not null)
+                {
+                    return TimestampMs == toCompare.TimestampMs && Text == toCompare.Text;
+                }
+                return false;
+            }
 
             /// <summary>
             /// Gets a hash code for the object
@@ -158,7 +165,14 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a == b, else false</returns>
-            public static bool operator ==(LyricsPhrase a, LyricsPhrase b) => a != null && a.Equals(b);
+            public static bool operator ==(LyricsPhrase a, LyricsPhrase b)
+            {
+                if (a is not null)
+                {
+                    return a.Equals(b);
+                }
+                return false;
+            }
 
             /// <summary>
             /// Compares two LyricsPhrase objects by not-equals
@@ -166,7 +180,14 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a != b, else false</returns>
-            public static bool operator !=(LyricsPhrase a, LyricsPhrase b) => a != null && !a.Equals(b);
+            public static bool operator !=(LyricsPhrase a, LyricsPhrase b)
+            {
+                if (a is not null)
+                {
+                    return !a.Equals(b);
+                }
+                return false;
+            }
 
             /// <summary>
             /// Compares two LyricsPhrase objects by inferior
@@ -174,7 +195,14 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is greater than b, else false</returns>
-            public static bool operator <(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs < b.TimestampMs && a.Text.CompareTo(b.Text) < 0;
+            public static bool operator <(LyricsPhrase a, LyricsPhrase b)
+            {
+                if (a is not null && b is not null)
+                {
+                    return a.TimestampMs < b.TimestampMs && a.Text.CompareTo(b.Text) < 0;
+                }
+                return false;
+            }
 
             /// <summary>
             /// Compares two LyricsPhrase objects by superior
@@ -182,7 +210,14 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is less than b, else false</returns>
-            public static bool operator >(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs > b.TimestampMs && a.Text.CompareTo(b.Text) > 0;
+            public static bool operator >(LyricsPhrase a, LyricsPhrase b)
+            {
+                if (a is not null && b is not null)
+                {
+                    return a.TimestampMs > b.TimestampMs && a.Text.CompareTo(b.Text) > 0;
+                }
+                return false;
+            }
 
             /// <summary>
             /// Compares two LyricsPhrase objects by inferior-or-equals
@@ -190,7 +225,14 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is greater than b, else false</returns>
-            public static bool operator <=(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs <= b.TimestampMs && a.Text.CompareTo(b.Text) <= 0;
+            public static bool operator <=(LyricsPhrase a, LyricsPhrase b)
+            {
+                if (a is not null && b is not null)
+                {
+                    return a.TimestampMs <= b.TimestampMs && a.Text.CompareTo(b.Text) <= 0;
+                }
+                return false;
+            }
 
             /// <summary>
             /// Compares two LyricsPhrase objects by superior-or-equals
@@ -198,7 +240,14 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is less than b, else false</returns>
-            public static bool operator >=(LyricsPhrase a, LyricsPhrase b) => a != null && b != null && a.TimestampMs >= b.TimestampMs && a.Text.CompareTo(b.Text) >= 0;
+            public static bool operator >=(LyricsPhrase a, LyricsPhrase b)
+            {
+                if (a is not null && b is not null)
+                {
+                    return a.TimestampMs >= b.TimestampMs && a.Text.CompareTo(b.Text) >= 0;
+                }
+                return false;
+            }
         }
 
         /// <summary>

--- a/ATL/Entities/LyricsInfo.cs
+++ b/ATL/Entities/LyricsInfo.cs
@@ -146,7 +146,7 @@ namespace ATL
             /// <returns>True if equals, else false</returns>
             public bool Equals(LyricsPhrase toCompare)
             {
-                if (toCompare is not null)
+                if (toCompare != null)
                 {
                     return TimestampMs == toCompare.TimestampMs && Text == toCompare.Text;
                 }
@@ -165,14 +165,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a == b, else false</returns>
-            public static bool operator ==(LyricsPhrase a, LyricsPhrase b)
-            {
-                if (a is not null)
-                {
-                    return a.Equals(b);
-                }
-                return false;
-            }
+            public static bool operator ==(LyricsPhrase a, LyricsPhrase b) => !ReferenceEquals(a, null) && a.Equals(b);
 
             /// <summary>
             /// Compares two LyricsPhrase objects by not-equals
@@ -180,14 +173,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a != b, else false</returns>
-            public static bool operator !=(LyricsPhrase a, LyricsPhrase b)
-            {
-                if (a is not null)
-                {
-                    return !a.Equals(b);
-                }
-                return false;
-            }
+            public static bool operator !=(LyricsPhrase a, LyricsPhrase b) => !ReferenceEquals(a, null) && !a.Equals(b);
 
             /// <summary>
             /// Compares two LyricsPhrase objects by inferior
@@ -195,14 +181,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is greater than b, else false</returns>
-            public static bool operator <(LyricsPhrase a, LyricsPhrase b)
-            {
-                if (a is not null && b is not null)
-                {
-                    return a.TimestampMs < b.TimestampMs && a.Text.CompareTo(b.Text) < 0;
-                }
-                return false;
-            }
+            public static bool operator <(LyricsPhrase a, LyricsPhrase b) => !ReferenceEquals(a, null) && !ReferenceEquals(b, null) && a.TimestampMs < b.TimestampMs && a.Text.CompareTo(b.Text) < 0;
 
             /// <summary>
             /// Compares two LyricsPhrase objects by superior
@@ -210,14 +189,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is less than b, else false</returns>
-            public static bool operator >(LyricsPhrase a, LyricsPhrase b)
-            {
-                if (a is not null && b is not null)
-                {
-                    return a.TimestampMs > b.TimestampMs && a.Text.CompareTo(b.Text) > 0;
-                }
-                return false;
-            }
+            public static bool operator >(LyricsPhrase a, LyricsPhrase b) => !ReferenceEquals(a, null) && !ReferenceEquals(b, null) && a.TimestampMs > b.TimestampMs && a.Text.CompareTo(b.Text) > 0;
 
             /// <summary>
             /// Compares two LyricsPhrase objects by inferior-or-equals
@@ -225,14 +197,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is greater than b, else false</returns>
-            public static bool operator <=(LyricsPhrase a, LyricsPhrase b)
-            {
-                if (a is not null && b is not null)
-                {
-                    return a.TimestampMs <= b.TimestampMs && a.Text.CompareTo(b.Text) <= 0;
-                }
-                return false;
-            }
+            public static bool operator <=(LyricsPhrase a, LyricsPhrase b) => !ReferenceEquals(a, null) && !ReferenceEquals(b, null) && a.TimestampMs <= b.TimestampMs && a.Text.CompareTo(b.Text) <= 0;
 
             /// <summary>
             /// Compares two LyricsPhrase objects by superior-or-equals
@@ -240,14 +205,7 @@ namespace ATL
             /// <param name="a">The first LyricsPhrase object</param>
             /// <param name="b">The second LyricsPhrase object</param>
             /// <returns>True if a is less than b, else false</returns>
-            public static bool operator >=(LyricsPhrase a, LyricsPhrase b)
-            {
-                if (a is not null && b is not null)
-                {
-                    return a.TimestampMs >= b.TimestampMs && a.Text.CompareTo(b.Text) >= 0;
-                }
-                return false;
-            }
+            public static bool operator >=(LyricsPhrase a, LyricsPhrase b) => !ReferenceEquals(a, null) && !ReferenceEquals(b, null) && a.TimestampMs >= b.TimestampMs && a.Text.CompareTo(b.Text) >= 0;
         }
 
         /// <summary>

--- a/ATL/Entities/LyricsInfo.cs
+++ b/ATL/Entities/LyricsInfo.cs
@@ -144,14 +144,7 @@ namespace ATL
             /// </summary>
             /// <param name="toCompare">The LyricsPhrase object to compare</param>
             /// <returns>True if equals, else false</returns>
-            public bool Equals(LyricsPhrase toCompare)
-            {
-                if (toCompare != null)
-                {
-                    return TimestampMs == toCompare.TimestampMs && Text == toCompare.Text;
-                }
-                return false;
-            }
+            public bool Equals(LyricsPhrase toCompare) => !ReferenceEquals(toCompare, null) && TimestampMs == toCompare.TimestampMs && Text == toCompare.Text;
 
             /// <summary>
             /// Gets a hash code for the object


### PR DESCRIPTION
Just tested 5.0.4 and I get a `NullReferenceException` using `IndexOf` for `SyncrhonizedLyrics` because of an issue of equality operators in `LyricsPhrase`...this PR fixes that. 

Sorry I should've caught this earlier 🙃

Hotfix release needed please :)