### PR TITLE
Is the System.Threading.Tasks.Extensions PackageReference needed?

### DIFF
--- a/ATL/ATL.csproj
+++ b/ATL/ATL.csproj
@@ -47,7 +47,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Ude.NetStandard" Version="1.2.0" />
     <PackageReference Include="Zomp.SyncMethodGenerator" Version="1.0.12" />
   </ItemGroup>


### PR DESCRIPTION
Just a thought whilst looking at some things - I don't think the System.Threading.Tasks.Extensions nuget package should be needed as it should be inbox in all the currently targeted TFMs?

 On a related note, I'm unclear if the z440.atl.core NuGet package should have a dependency on the Zomp.SyncMethodGenerator NuGet package or if it should be a development only dependency, but I don't know exactly how that works so I 'm not sure.