### PR TITLE
Set PrivateAssets=All on the Zomp.SyncMethodGenerator PackageReference

### DIFF
--- a/ATL/ATL.csproj
+++ b/ATL/ATL.csproj
@@ -48,8 +48,9 @@
 
   <ItemGroup>
     <PackageReference Include="Ude.NetStandard" Version="1.2.0" />
-    <PackageReference Include="Zomp.SyncMethodGenerator" Version="1.0.12" >
-      <ExcludeAssets>Runtime</ExcludeAssets>
+    <PackageReference Include="Zomp.SyncMethodGenerator" Version="1.0.12">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Refs https://github.com/Zeugma440/atldotnet/pull/251#issuecomment-1956829532

It looks like there was an issue in the past where the Zomp.SyncMethodGenerator NuGet package itself wasn't marked as a DevelopmentDependency when it should have been - https://github.com/zompinc/sync-method-generator/issues/11.

If I add the current version of the package to a new project, it gets added as 
```xml
    <PackageReference Include="Zomp.SyncMethodGenerator" Version="1.3.6">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
    </PackageReference>
```