### PR TITLE
BufferedBinaryReader.cs must read all bytes

### DIFF
--- a/ATL/Utils/BufferedBinaryReader.cs
+++ b/ATL/Utils/BufferedBinaryReader.cs
@@ -186,9 +186,14 @@ namespace ATL
                 {
                     availableBytes = 0;
                 }
-
+                
                 // ...then retrieve the rest by reading the stream
-                int readBytes = stream.Read(buffer, offset + availableBytes, count - availableBytes);
+                var readBytes = 0;
+                while (readBytes != count - availableBytes)
+                {
+                    var read = stream.Read(buffer, offset + readBytes, count - availableBytes - readBytes);
+                    readBytes += read;
+                }
 
                 streamPosition += readBytes;
                 stream.Position = streamPosition;


### PR DESCRIPTION
When handling BufferedBinaryReader, one must read a specified number of characters during the read operation. This approach can likely resolve issues related to reading an insufficient number of characters. #266 

