### PR TITLE
Handle multiple data for string atoms

### DIFF
--- a/ATL/AudioData/IO/MP4.cs
+++ b/ATL/AudioData/IO/MP4.cs
@@ -1437,7 +1437,31 @@ namespace ATL.AudioData.IO
 
                 if (1 == dataClass) // UTF-8 Text
                 {
-                    strData = Encoding.UTF8.GetString(source.ReadBytes((int)metadataSize - 16));
+                    var strlen = metadataSize;
+                    long lastLocation;
+                    var currentData = new List<string>();
+
+                    do
+                    {
+                        var dataSize = Math.Max(0, (int) strlen - 16);
+                        if (dataSize > 0)
+                        {
+                            strData = Encoding.UTF8.GetString(source.ReadBytes((int)strlen - 16));
+                            currentData.Add(strData);
+                        }
+
+                        lastLocation = source.BaseStream.Position;
+                        strlen = navigateToAtom(source, "data");
+                        
+                        if (strlen <= 0) continue;
+                        
+                        source.BaseStream.Seek(3, SeekOrigin.Current); // We're only looking for the last byte of the flag
+                        dataClass = source.ReadByte();
+                        source.BaseStream.Seek(4, SeekOrigin.Current); // 4-byte NULL space
+                        metadataSize += strlen;
+                    } while (strlen > 0);
+                    source.BaseStream.Seek(lastLocation, SeekOrigin.Begin);
+                    strData = string.Join(Settings.InternalValueSeparator, currentData);
                     SetMetaField(atomHeader, strData, readTagParams.ReadAllMetaFrames);
                 }
                 else if (21 == dataClass) // int8-16-24-32


### PR DESCRIPTION
The MP4 container supports multiple data atoms within a single metadata field atom. However, this is handled incorrectly now. The extra data atom is treated as an additional field, and this also causes the seek position to be incorrect. Consequently, parsing of other fields, such as the `trkn` field might also break. 

See https://github.com/jellyfin/jellyfin/issues/13004 for more info