### PR TITLE
Don't format LRC timestamp with DDdHH:MM:SS

### DIFF
--- a/ATL.unit-test/Misc/UtilsTest.cs
+++ b/ATL.unit-test/Misc/UtilsTest.cs
@@ -25,6 +25,8 @@ namespace ATL.test
             Assert.AreEqual("01:01:00.0", Utils.EncodeTimecode_ms(60 * 60 * 1000 + 60 * 1000));
             // Display d, h, m, s and ms
             Assert.AreEqual("2d 01:01:00.0", Utils.EncodeTimecode_ms(48 * 60 * 60 * 1000 + 60 * 60 * 1000 + 60 * 1000));
+            // Display m, s and ms for very long durations in MM:SS.UUUU format
+            Assert.AreEqual("2941:01.0", Utils.EncodeTimecode_ms(48 * 60 * 60 * 1000 + 60 * 60 * 1000 + 60 * 1000 + 1000, true));
         }
 
         [TestMethod]

--- a/ATL/Entities/LyricsInfo.cs
+++ b/ATL/Entities/LyricsInfo.cs
@@ -350,7 +350,7 @@ namespace ATL
             // Lyrics
             foreach (var line in SynchronizedLyrics)
             {
-                sb.Append('[').Append(Utils.EncodeTimecode_ms(line.TimestampMs)).Append(']').Append(line.Text).Append('\n');
+                sb.Append('[').Append(Utils.EncodeTimecode_ms(line.TimestampMs, true)).Append(']').Append(line.Text).Append('\n');
             }
 
             return sb.ToString();

--- a/ATL/Utils/Utils.cs
+++ b/ATL/Utils/Utils.cs
@@ -45,21 +45,26 @@ namespace Commons
         /// <summary>
         /// Format the given duration using the following format
         ///     DDdHH:MM:SS.UUUU
+        ///     OR
+        ///     MM:SS.UUUU
         ///     
         ///  Where
         ///     DD is the number of days, if applicable (i.e. durations of less than 1 day won't display the "DDd" part)
         ///     HH is the number of hours, if applicable (i.e. durations of less than 1 hour won't display the "HH:" part)
-        ///     MM is the number of minutes
+        ///     MM is the number of minutes, when using MMSS format, this will extend beyond two digits if necessary
         ///     SS is the number of seconds
         ///     UUUU is the number of milliseconds
         /// </summary>
         /// <param name="milliseconds">Duration to format (in milliseconds)</param>
+        /// <param name="useMmSsFormat">Format in MM:SS.UUUU format. Default is false</param>
         /// <returns>Formatted duration according to the abovementioned convention</returns>
-        public static string EncodeTimecode_ms(long milliseconds)
+        public static string EncodeTimecode_ms(long milliseconds, bool useMmSsFormat = false)
         {
             long seconds = Convert.ToInt64(Math.Floor(milliseconds / 1000.00));
+            
+            var encodedString = useMmSsFormat ? EncodeMmSsTimecode_s(seconds) : EncodeTimecode_s(seconds);
 
-            return EncodeTimecode_s(seconds) + "." + (milliseconds - seconds * 1000);
+            return encodedString + "." + (milliseconds - seconds * 1000);
         }
 
         /// <summary>
@@ -91,6 +96,29 @@ namespace Commons
 
             if (d > 0) return d + "d " + hStr + ":" + mStr + ":" + sStr;
             if (h > 0) return hStr + ":" + mStr + ":" + sStr;
+            return mStr + ":" + sStr;
+        }
+        
+        /// <summary>
+        /// Format the given duration using the following format
+        ///     MM:SS
+        ///     
+        ///  Where
+        ///     MM is the number of minutes, this will extend beyond two digits if necessary
+        ///     SS is the number of seconds
+        /// </summary>
+        /// <param name="seconds">Duration to format (in seconds)</param>
+        /// <returns>Formatted duration according to the abovementioned convention</returns>
+        public static string EncodeMmSsTimecode_s(long seconds)
+        {
+            var m = Convert.ToInt64(Math.Floor(seconds / 60.00));
+            var s = seconds - 60 * m;
+
+            var mStr = m.ToString();
+            if (1 == mStr.Length) mStr = "0" + mStr;
+            var sStr = s.ToString();
+            if (1 == sStr.Length) sStr = "0" + sStr;
+            
             return mStr + ":" + sStr;
         }
 


### PR DESCRIPTION
LRC format generally doesn’t support days and hours because the original format explicitly uses the `[mm:ss.xx]lyric` format. Encoding synchronized lyrics with the current DDdHH:MM:SS format would break certain LRC parsers that weren’t designed to handle hours and days. For example, the LrcParser used by Jellyfin was using regex to match the mm:ss pattern: https://github.com/kfstorm/LrcParser/blob/95aaffde330efaa252b53654803e7d8794048fc2/LrcParser/LrcFile.cs#L157

This PR now formats the timestamps in MM:SS.UUUU format and allows MM to extend beyond double digits when necessary, which should be more compatible than current format.

See https://github.com/jellyfin/jellyfin/issues/13260 for more info