### PR TITLE
Update nuget_build_release.yml to prevent character escaping

### DIFF
--- a/.github/workflows/nuget_build_release.yml
+++ b/.github/workflows/nuget_build_release.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: "Create NuGet release note file"
         run: |
-          echo "${{ github.event.release.body }}" > PACKAGE-RELEASE-NOTES.txt
+          cat << 'EOF-WORKFLOW' > PACKAGE-RELEASE-NOTES.txt
+          ${{ github.event.release.body }}
+          EOF-WORKFLOW
 
       - name: "Restore packages"
         run: dotnet restore "${{ env.PROJECT_PATH }}"


### PR DESCRIPTION
I'm glad to see the workflow worked flawlessly, however I noticed in [the logs](https://github.com/Zeugma440/atldotnet/actions/runs/13214774585/job/36892724519#step:4:27) that during the release file creation the GitHub Action executed commands that did not exist. These commands were text surrounded by **``**. This had the consequence of removing them from the release file, which made [weird sentences on the NuGet release notes](https://www.nuget.org/packages/z440.atl.core/6.16.0#releasenotes-body-tab).  

But more importantly, this may compromise the build workflow if you accidentally were to include any kind of ill-intended string in your release body. While linux and bash systems are not my zone of confort, I managed to find a way to create that file in a way that should ignore escape characters, or, at least, those surrounded by **``**.
