### PR TITLE
Check year range in both side

### DIFF
--- a/ATL.unit-test/IO/HighLevel.cs
+++ b/ATL.unit-test/IO/HighLevel.cs
@@ -532,7 +532,13 @@ namespace ATL.test.IO
 
                 Assert.AreEqual(0, theTrack.Year);
                 Assert.AreEqual(DateTime.MinValue.ToString(), theTrack.Date.ToString());
-
+                
+                // Test additional case where the year is an invalid value
+                theTrack.Year = 99999999;
+                Assert.AreEqual(0, theTrack.Year);
+                
+                theTrack.OriginalReleaseYear = 99999999;
+                Assert.AreEqual(0, theTrack.OriginalReleaseYear);
 
                 // Get rid of the working copy
                 if (Settings.DeleteAfterSuccess) File.Delete(testFileLocation);

--- a/ATL/Entities/Track.cs
+++ b/ATL/Entities/Track.cs
@@ -238,7 +238,7 @@ namespace ATL
             }
             set
             {
-                if (canUseValue(value) && value.Value > DateTime.MinValue.Year) Date = new DateTime(value.Value, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                if (canUseValue(value) && value.Value > DateTime.MinValue.Year && value.Value < DateTime.MaxValue.Year) Date = new DateTime(value.Value, 1, 1, 0, 0, 0, DateTimeKind.Utc);
                 else if (Settings.NullAbsentValues) Date = null;
                 else Date = DateTime.MinValue;
                 isYearExplicit = true;
@@ -269,7 +269,7 @@ namespace ATL
             }
             set
             {
-                if (canUseValue(value) && value.Value > DateTime.MinValue.Year) OriginalReleaseDate = new DateTime(value.Value, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                if (canUseValue(value) && value.Value > DateTime.MinValue.Year && value.Value < DateTime.MaxValue.Year) OriginalReleaseDate = new DateTime(value.Value, 1, 1, 0, 0, 0, DateTimeKind.Utc);
                 else if (Settings.NullAbsentValues) OriginalReleaseDate = null;
                 else OriginalReleaseDate = DateTime.MinValue;
                 isORYearExplicit = true;


### PR DESCRIPTION
We cannot expect all users will always tag the files in the year tag with valid years. A lot of them will abuse this tag field to tag a full date in pure number, like 19991231. Such date is not parseable by DateTime.TryParse and is not within valid year range for DateTime constructor. We check if that is the case before creating a new DateTime instance.

See https://github.com/jellyfin/jellyfin/issues/13669 and https://github.com/jellyfin/jellyfin/issues/11576 

For some format (like mp4) this case is already handled and fallback to the smallest date: https://github.com/jellyfin/jellyfin/issues/13514

This PR makes the explicit years to also behave similar to that, which is an acceptable behavior when the user has specified an invalid year.