### PR TITLE
Fix Capacity -2 fromBinaryData

### DIFF
--- a/ATL/AudioData/IO/APEtag.cs
+++ b/ATL/AudioData/IO/APEtag.cs
@@ -240,8 +240,14 @@ namespace ATL.AudioData.IO
                 if (frameDataSize > 0)
                 {
                     var frameNameLow = frameName.ToLower();
+                    
+                    PictureInfo.PIC_TYPE picType = decodeAPEPictureType(frameName);
+                    
                     var isPicture = picValuesLower.Contains(frameNameLow) ||
-                                    (frameDataSize > 1000 && !frameNameLow.Contains("lyrics") && !frameNameLow.Equals("logfile"));
+                                    (frameDataSize > 1000 && !frameNameLow.Contains("lyrics") && 
+                                     !frameNameLow.Equals("logfile") &&
+                                     picType != PictureInfo.PIC_TYPE.Unsupported);
+
                     if (!isPicture)
                     {
                         /*
@@ -259,12 +265,10 @@ namespace ATL.AudioData.IO
                     }
                     else // Pictures
                     {
-                        PictureInfo.PIC_TYPE picType = decodeAPEPictureType(frameName);
-
                         var picturePosition = picType.Equals(PictureInfo.PIC_TYPE.Unsupported)
                             ? takePicturePosition(getImplementedTagType(), frameName)
                             : takePicturePosition(picType);
-
+                        
                         if (readTagParams.ReadPictures)
                         {
                             // Description seems to be a null-terminated ANSI string containing 


### PR DESCRIPTION
Heey, my PR will fix a small issue you have in the library, specifically for APEtag
You assume all tags with a length of >1000 are pictures but this is not the case for some tags, the one I noticed that got hit the most was "Acoustid Fingerprint" which are >3000bytes