### PR TITLE
Fix lrc milisecond encode format

### DIFF
--- a/ATL.unit-test/Misc/UtilsTest.cs
+++ b/ATL.unit-test/Misc/UtilsTest.cs
@@ -26,7 +26,12 @@ namespace ATL.test
             // Display d, h, m, s and ms
             Assert.AreEqual("2d 01:01:00.0", Utils.EncodeTimecode_ms(48 * 60 * 60 * 1000 + 60 * 60 * 1000 + 60 * 1000));
             // Display m, s and ms for very long durations in MM:SS.UUUU format
-            Assert.AreEqual("2941:01.0", Utils.EncodeTimecode_ms(48 * 60 * 60 * 1000 + 60 * 60 * 1000 + 60 * 1000 + 1000, true));
+            Assert.AreEqual("2941:01.0", Utils.EncodeTimecode_ms(48 * 60 * 60 * 1000 + 60 * 60 * 1000 + 60 * 1000 + 1000, Utils.TimecodeEncodeFormat.MM_SS_UUUU));
+            // Display LRC format with correct rounding
+            Assert.AreEqual("00:21.05", Utils.EncodeTimecode_ms(21 * 1000 + 50, Utils.TimecodeEncodeFormat.MM_SS_XX));
+            Assert.AreEqual("00:21.01", Utils.EncodeTimecode_ms(21 * 1000 + 5, Utils.TimecodeEncodeFormat.MM_SS_XX));
+            Assert.AreEqual("00:21.00", Utils.EncodeTimecode_ms(21 * 1000 + 1, Utils.TimecodeEncodeFormat.MM_SS_XX));
+            Assert.AreEqual("00:29.67", Utils.EncodeTimecode_ms(29 * 1000 + 67 * 10, Utils.TimecodeEncodeFormat.MM_SS_XX));
         }
 
         [TestMethod]
@@ -36,6 +41,10 @@ namespace ATL.test
             Assert.AreEqual(2 * 1000 + 2, Utils.DecodeTimecodeToMs("00:02.2"));
             // Display m, s and ms
             Assert.AreEqual(62 * 1000 + 2, Utils.DecodeTimecodeToMs("01:02.2"));
+            // Correctly parse lrc specific time code
+            Assert.AreEqual(21 * 1000 + 5 * 10, Utils.DecodeTimecodeToMs("00:21.05", true));
+            Assert.AreEqual(25 * 1000, Utils.DecodeTimecodeToMs("00:25.00", true));
+            Assert.AreEqual(29 * 1000 + 67 * 10, Utils.DecodeTimecodeToMs("00:29.67", true));
             // Display h, m, s and ms
             Assert.AreEqual(60 * 60 * 1000 + 60 * 1000 + 16 * 1000 + 612, Utils.DecodeTimecodeToMs("01:01:16.612"));
             Assert.AreEqual(60 * 60 * 1000 + 60 * 1000 + 16 * 1000 + 612, Utils.DecodeTimecodeToMs("01:01:16,612"));

--- a/ATL/Entities/LyricsInfo.cs
+++ b/ATL/Entities/LyricsInfo.cs
@@ -148,8 +148,8 @@ namespace ATL
                 string timestampEnd = "",
                 List<LyricsPhrase> beats = null)
             {
-                TimestampStart = Utils.DecodeTimecodeToMs(timestampStart);
-                TimestampEnd = Utils.DecodeTimecodeToMs(timestampEnd);
+                TimestampStart = Utils.DecodeTimecodeToMs(timestampStart, true);
+                TimestampEnd = Utils.DecodeTimecodeToMs(timestampEnd, true);
                 Text = text;
                 if (beats != null) Beats = beats.Select(b => new LyricsPhrase(b)).ToList();
             }
@@ -484,7 +484,7 @@ namespace ATL
                             if (0 == beatLyrics.Length)
                             {
                                 // Timestamp end of last beat
-                                int timestampEnd = Utils.DecodeTimecodeToMs(beatStart);
+                                int timestampEnd = Utils.DecodeTimecodeToMs(beatStart, true);
                                 if (timestampEnd > 0)
                                 {
                                     // Duplicate with timestamp end
@@ -586,14 +586,14 @@ namespace ATL
             // Lyrics
             foreach (var line in SynchronizedLyrics)
             {
-                sb.Append('[').Append(Utils.EncodeTimecode_ms(line.TimestampStart, true)).Append(']');
+                sb.Append('[').Append(Utils.EncodeTimecode_ms(line.TimestampStart, Utils.TimecodeEncodeFormat.MM_SS_XX)).Append(']');
                 if (line.Beats is { Count: > 0 })
                 {
                     // LRC A2
                     foreach (var beat in line.Beats)
                     {
-                        sb.Append('<').Append(Utils.EncodeTimecode_ms(beat.TimestampStart, true)).Append('>').Append(beat.Text);
-                        if (beat.TimestampEnd > -1) sb.Append('<').Append(Utils.EncodeTimecode_ms(beat.TimestampStart, true)).Append('>');
+                        sb.Append('<').Append(Utils.EncodeTimecode_ms(beat.TimestampStart, Utils.TimecodeEncodeFormat.MM_SS_XX)).Append('>').Append(beat.Text);
+                        if (beat.TimestampEnd > -1) sb.Append('<').Append(Utils.EncodeTimecode_ms(beat.TimestampStart, Utils.TimecodeEncodeFormat.MM_SS_XX)).Append('>');
                     }
                 }
                 else
@@ -624,9 +624,9 @@ namespace ATL
                 // Index
                 sb.Append(index++).Append('\n');
                 // Timecodes
-                sb.Append(Utils.EncodeTimecode_ms(line.TimestampStart, true).Replace('.', ','));
+                sb.Append(Utils.EncodeTimecode_ms(line.TimestampStart, Utils.TimecodeEncodeFormat.MM_SS_UUUU).Replace('.', ','));
                 sb.Append(" --> ");
-                sb.Append(Utils.EncodeTimecode_ms(line.TimestampEnd, true).Replace('.', ','));
+                sb.Append(Utils.EncodeTimecode_ms(line.TimestampEnd, Utils.TimecodeEncodeFormat.MM_SS_UUUU).Replace('.', ','));
                 sb.Append('\n');
                 // Text
                 sb.Append(line.Text).Append('\n');


### PR DESCRIPTION
The LRC format uses a different timecode convention from the one we are currently using. It represents time as MM:SS:XX, where XX is always two digits, indicating hundredths of a second (10 ms). Encoding the timecode simply as UUUU ms will cause most LRC parsers to fail.

Additionally, our current parser incorrectly decodes LRC timestamps, making the millisecond value only one-tenth of the intended value. This, in turn, causes converted formats—such as SRT—to have incorrect timecodes.

See https://github.com/jellyfin/jellyfin/issues/14671 for more info.