### PR TITLE
Minor performance improvements

### DIFF
--- a/ATL/AudioData/IO/MKA.cs
+++ b/ATL/AudioData/IO/MKA.cs
@@ -13,14 +13,14 @@ namespace ATL.AudioData.IO
 {
     /// <summary>
     /// Class for Matroska Audio files manipulation (extension : .MKA)
-    /// 
+    ///
     /// Implementation notes
     /// - Padding Elements are not supported
     /// - Chapters : Multiple EditionEntries are not supported; only 1st default, non-hidden is used
     /// - Chapters : Nested ChapterAtoms are not supported; only 1st level enabled, non-hidden are used
     /// - Cues : CuePoints are not part of readable not writable metadata
     /// - Tags : Nested tags are not supported
-    /// 
+    ///
     /// </summary>
     internal partial class MKA : MetaDataIO, IAudioDataIO
     {
@@ -200,7 +200,7 @@ namespace ATL.AudioData.IO
         private const string ZONE_CHAPTERS = "chapters";
 
 
-        // == Private declarations 
+        // == Private declarations
 
         // Metadata
         private AudioFormat audioFormat;

--- a/ATL/AudioData/IO/PSF.cs
+++ b/ATL/AudioData/IO/PSF.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace ATL.AudioData.IO
 {
     /// <summary>
-    /// Class for Portable Sound Format files manipulation (extensions : .PSF, .PSF1, .PSF2, 
+    /// Class for Portable Sound Format files manipulation (extensions : .PSF, .PSF1, .PSF2,
     /// .MINIPSF, .MINIPSF1, .MINIPSF2, .SSF, .MINISSF, .DSF, .MINIDSF, .GSF, .MINIGSF, .QSF, .MINISQF)
     /// According to Neil Corlett's specifications v. 1.6
     /// </summary>
@@ -244,8 +244,8 @@ namespace ATL.AudioData.IO
             long initialPosition = source.Position;
             Encoding encoding = Utils.Latin1Encoding;
 
-            byte[] buffer = new byte[5];
-            if (source.Read(buffer, 0, buffer.Length) < buffer.Length) return false;
+            Span<byte> buffer = stackalloc byte[5];
+            if (source.Read(buffer) < buffer.Length) return false;
             tag.TagHeader = Utils.Latin1Encoding.GetString(buffer);
 
             if (TAG_HEADER == tag.TagHeader)
@@ -287,7 +287,7 @@ namespace ATL.AudioData.IO
                     }
 
                     s = readPSFLine(source, encoding);
-                } // Metadata lines 
+                } // Metadata lines
                 SetMetaField(lastKey, lastValue, readTagParams.ReadAllMetaFrames);
 
                 // PSF files without any 'length' tag take default duration, regardless of 'fade' value

--- a/ATL/AudioData/IO/VorbisTag.cs
+++ b/ATL/AudioData/IO/VorbisTag.cs
@@ -12,9 +12,9 @@ namespace ATL.AudioData.IO
 {
     /// <summary>
     /// Class for Vorbis tags (VorbisComment) manipulation
-    /// 
+    ///
     /// TODO - Rewrite as "pure" helper, with Ogg and FLAC inheriting MetaDataIO
-    /// 
+    ///
     /// </summary>
     partial class VorbisTag : MetaDataIO
     {
@@ -183,7 +183,7 @@ namespace ATL.AudioData.IO
             // NB : Handled this way to retrieve badly formatted chapter indexes (e.g. CHAPTER2, CHAPTER02NAME...)
             int i = 7;
             while (i < fieldName.Length && char.IsDigit(fieldName[i])) i++;
-            uint chapterId = uint.Parse(fieldName.Substring(7, i - 7));
+            uint chapterId = uint.Parse(fieldName.AsSpan(7, i - 7));
 
             ChapterInfo info = tagData.Chapters.FirstOrDefault(c => c.UniqueNumericID == chapterId);
             if (null == info)
@@ -582,7 +582,7 @@ namespace ATL.AudioData.IO
             w.Write(Utils.Latin1Encoding.GetBytes(frameCode + "="));
             w.Write(Encoding.UTF8.GetBytes(text));
 
-            // Go back to frame size location to write its actual size 
+            // Go back to frame size location to write its actual size
             var finalFramePos = w.Position;
             w.Seek(frameSizePos, SeekOrigin.Begin);
             w.Write(StreamUtils.EncodeUInt32((uint)(finalFramePos - frameSizePos - 4)));
@@ -602,7 +602,7 @@ namespace ATL.AudioData.IO
                 w.Write(Utils.EncodeTo64(picStream.ToArray()));
             }
 
-            // Go back to frame size location to write its actual size 
+            // Go back to frame size location to write its actual size
             var finalFramePos = w.Position;
             w.Seek(frameSizePos, SeekOrigin.Begin);
             w.Write(StreamUtils.EncodeUInt32((uint)(finalFramePos - frameSizePos - 4)));

--- a/ATL/AudioData/MetaDataIO.cs
+++ b/ATL/AudioData/MetaDataIO.cs
@@ -379,7 +379,7 @@ namespace ATL.AudioData.IO
         }
 
         /// <summary>
-        /// Set a new metadata field with the given information 
+        /// Set a new metadata field with the given information
         /// </summary>
         /// <param name="ID">ID of the metadata field</param>
         /// <param name="dataIn">Metadata</param>
@@ -526,7 +526,7 @@ namespace ATL.AudioData.IO
         {
             if (Settings.AutoFormatAdditionalDates && value.StartsWith(DATETIME_PREFIX, StringComparison.OrdinalIgnoreCase))
             {
-                return EncodeDate(DateTime.FromFileTime(long.Parse(value[DATETIME_PREFIX.Length..])));
+                return EncodeDate(DateTime.FromFileTime(long.Parse(value.AsSpan()[DATETIME_PREFIX.Length..])));
             }
             return value;
         }

--- a/ATL/AudioData/Utils/TrackUtils.cs
+++ b/ATL/AudioData/Utils/TrackUtils.cs
@@ -44,7 +44,7 @@ namespace ATL.AudioData
 
             if (i > 0 && i < maxLongLength)
             {
-                long number = long.Parse(str.Substring(0, i));
+                long number = long.Parse(str.AsSpan(0, i));
                 if (number > ushort.MaxValue) number = 0;
                 return (ushort)number;
             }
@@ -119,7 +119,7 @@ namespace ATL.AudioData
             var strLen = i - delimiterEnd + 1;
             if (i > delimiterOffset && strLen < maxLongLength)
             {
-                long number = long.Parse(str.Substring(delimiterEnd, strLen));
+                long number = long.Parse(str.AsSpan(delimiterEnd, strLen));
                 if (number > ushort.MaxValue) number = 0;
                 return (ushort)number;
             }

--- a/ATL/AudioData/Utils/XmlArray.cs
+++ b/ATL/AudioData/Utils/XmlArray.cs
@@ -332,7 +332,8 @@ namespace ATL.AudioData
         {
             string pfx = null;
             string name = key;
-            if (name.Contains('[')) name = name[..name.IndexOf('[')]; // Remove [x]'s
+            int index = name.IndexOf('[');
+            if (index > -1) name = name[..index]; // Remove [x]'s
             int pfxIdfx = name.IndexOf(':');
             if (pfxIdfx > -1)
             {

--- a/ATL/CatalogDataReaders/BinaryLogic/Cue.cs
+++ b/ATL/CatalogDataReaders/BinaryLogic/Cue.cs
@@ -105,7 +105,7 @@ namespace ATL.CatalogDataReaders.BinaryLogic
                             if ("REM".Equals(firstWord, StringComparison.OrdinalIgnoreCase))
                             {
                                 if (comments.Length > 0) comments.Append(Settings.InternalValueSeparator);
-                                comments.Append(s.Substring(firstBlank + 1, s.Length - firstBlank - 1));
+                                comments.Append(s.AsSpan(firstBlank + 1, s.Length - firstBlank - 1));
                             }
                             else if ("PERFORMER".Equals(firstWord, StringComparison.OrdinalIgnoreCase))
                             {

--- a/ATL/Entities/MetadataHolder.cs
+++ b/ATL/Entities/MetadataHolder.cs
@@ -161,14 +161,14 @@ namespace ATL
                         StringBuilder dateTimeBuilder = new StringBuilder();
                         dateTimeBuilder.Append(year).Append('-');
                         dateTimeBuilder.Append(dayMonth.AsSpan(2, 2)).Append('-');
-                        dateTimeBuilder.Append(dayMonth[..2]);
+                        dateTimeBuilder.Append(dayMonth.AsSpan(0, 2));
                         string time = Utils.ProtectValue(tagData[Field.RECORDING_TIME]); // Try to add time if available
                         if (time.Length >= 4)
                         {
                             dateTimeBuilder.Append('T');
-                            dateTimeBuilder.Append(time[..2]).Append(':');
+                            dateTimeBuilder.Append(time.AsSpan(0, 2)).Append(':');
                             dateTimeBuilder.Append(time.AsSpan(2, 2)).Append(':');
-                            dateTimeBuilder.Append((6 == time.Length) ? time.Substring(4, 2) : "00");
+                            dateTimeBuilder.Append((6 == time.Length) ? time.AsSpan(4, 2) : "00");
                         }
                         success = DateTime.TryParse(dateTimeBuilder.ToString(), out result);
                     }
@@ -192,9 +192,9 @@ namespace ATL
                         string time = Utils.ProtectValue(tagData[Field.RECORDING_TIME]); // Try to add time if available
                         if (time.Length < 4 || !Utils.IsNumeric(time)) return result;
 
-                        result.AddHours(int.Parse(time[..2]));
+                        result.AddHours(int.Parse(time.AsSpan(0, 2)));
                         result.AddMinutes(int.Parse(time.AsSpan(2, 2)));
-                        if (6 == time.Length) result.AddSeconds(int.Parse(time.Substring(4, 2)));
+                        if (6 == time.Length) result.AddSeconds(int.Parse(time.AsSpan(4, 2)));
                     }
                 }
                 return result;

--- a/ATL/Factory.cs
+++ b/ATL/Factory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace ATL
@@ -14,7 +15,7 @@ namespace ATL
         protected IDictionary<string, IList<T>> formatListByExt;
 
         /// <summary>
-        /// List of all formats supported by this kind of data reader 
+        /// List of all formats supported by this kind of data reader
         /// They are indexed by MIME-type to speed up matching
         /// </summary>
         protected IDictionary<string, IList<T>> formatListByMime;
@@ -62,12 +63,13 @@ namespace ATL
         /// Gets the valid formats from the given file path, using the file extension as key
         /// </summary>
         /// <param name="path">Path of the file which format to recognize</param>
-        /// <returns>List of the valid formats matching the extension of the given file, 
+        /// <returns>List of the valid formats matching the extension of the given file,
         /// or null if none recognized or the file does not exist</returns>
         public IList<T> getFormatsFromPath(string path)
         {
             IList<T> result = null;
-            string extension = path.Contains('.') ? path.Substring(path.LastIndexOf('.'), path.Length - path.LastIndexOf('.')).ToLower() : path;
+            int index = path.LastIndexOf('.');
+            string extension = -1 == index ? path : path[index..].ToLower();
 
             if (formatListByExt.TryGetValue(extension, out var formats) && formats != null && formats.Count > 0)
             {
@@ -81,7 +83,7 @@ namespace ATL
         /// Gets the valid formats from the given MIME-type
         /// </summary>
         /// <param name="mimeType">MIME-type to recognize</param>
-        /// <returns>List of the valid formats matching the MIME-type of the given file, 
+        /// <returns>List of the valid formats matching the MIME-type of the given file,
         /// or null if none recognized</returns>
         public IList<T> getFormatsFromMimeType(string mimeType)
         {

--- a/ATL/Utils/Utils.cs
+++ b/ATL/Utils/Utils.cs
@@ -43,7 +43,7 @@ namespace Commons
         private static readonly string[] NUMERAL_DIGITS = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
         private static readonly string[] ARABIC_DIGITS = { "٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩" };
         private static readonly string[] FARSI_DIGITS = { "۰", "۱", "۲", "۳", "۴", "۵", "۶", "۷", "۸", "۹" };
-        
+
         private static long RoundToNearest10(long number)
         {
             return (number + 5) / 10;
@@ -58,7 +58,7 @@ namespace Commons
         {
             return value ?? "";
         }
-        
+
         public enum TimecodeEncodeFormat
         {
             DD_HH_MM_SS_UUUU,
@@ -73,7 +73,7 @@ namespace Commons
         ///     MM:SS.UUUU
         ///     OR
         ///     MM:SS.XX(XX will always have 2 digits)
-        ///     
+        ///
         ///  Where
         ///     DD is the number of days, if applicable (i.e. durations of less than 1 day won't display the "DDd" part)
         ///     HH is the number of hours, if applicable (i.e. durations of less than 1 hour won't display the "HH:" part)
@@ -98,7 +98,7 @@ namespace Commons
         /// <summary>
         /// Format the given duration using the following format
         ///     DDdHH:MM:SS
-        ///     
+        ///
         ///  Where
         ///     DD is the number of days, if applicable (i.e. durations of less than 1 day won't display the "DDd" part)
         ///     HH is the number of hours, if applicable (i.e. durations of less than 1 hour won't display the "HH:" part)
@@ -130,7 +130,7 @@ namespace Commons
         /// <summary>
         /// Format the given duration using the following format
         ///     MM:SS
-        ///     
+        ///
         ///  Where
         ///     MM is the number of minutes, this will extend beyond two digits if necessary
         ///     SS is the number of seconds
@@ -163,7 +163,7 @@ namespace Commons
 
             bool valid = false;
 
-        
+
             int days = 0;
             int hours = 0;
             int milliseconds = 0;
@@ -195,8 +195,8 @@ namespace Commons
                     string[] subPart = parts[^3].Split('d');
                     if (subPart.Length > 1)
                     {
-                        days = int.Parse(subPart[0].Trim());
-                        hours = int.Parse(subPart[1].Trim());
+                        days = int.Parse(subPart[0].AsSpan().Trim());
+                        hours = int.Parse(subPart[1].AsSpan().Trim());
                     }
                     else
                     {
@@ -288,8 +288,8 @@ namespace Commons
                     }
                     break;
                 case 6:
-                    year = int.Parse(str.Substring(0, 4));
-                    int month = int.Parse(str.Substring(4, 2));
+                    year = int.Parse(str.AsSpan(0, 4));
+                    int month = int.Parse(str.AsSpan(4, 2));
                     if (year >= DateTime.MinValue.Year && year <= DateTime.MaxValue.Year && month <= DateTime.MaxValue.Month)
                     {
                         date = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -297,9 +297,9 @@ namespace Commons
                     }
                     break;
                 case 8:
-                    year = int.Parse(str.Substring(0, 4));
-                    month = int.Parse(str.Substring(4, 2));
-                    int day = int.Parse(str.Substring(6, 2));
+                    year = int.Parse(str.AsSpan(0, 4));
+                    month = int.Parse(str.AsSpan(4, 2));
+                    int day = int.Parse(str.AsSpan(6, 2));
                     if (year >= DateTime.MinValue.Year && year <= DateTime.MaxValue.Year && month <= DateTime.MaxValue.Month && day <= DateTime.MaxValue.Day)
                     {
                         date = new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc);
@@ -347,7 +347,7 @@ namespace Commons
         /// <param name="value">Value to transform</param>
         /// <param name="length">Target length of the final string</param>
         /// <param name="paddingChar">Character to use if padding is needed</param>
-        /// <param name="padRight">True if the padding has to be done on the right-side of the target string; 
+        /// <param name="padRight">True if the padding has to be done on the right-side of the target string;
         /// false if the padding has to be done on the left-side (optional; default value = true)</param>
         /// <returns>Reprocessed string of given length, according to rules documented in the method description</returns>
         public static string BuildStrictLengthString(int value, int length, char paddingChar, bool padRight = true)
@@ -362,7 +362,7 @@ namespace Commons
         /// <param name="value">Value to transform</param>
         /// <param name="length">Target length of the final string</param>
         /// <param name="paddingChar">Character to use if padding is needed</param>
-        /// <param name="padRight">True if the padding has to be done on the right-side of the target string; 
+        /// <param name="padRight">True if the padding has to be done on the right-side of the target string;
         /// false if the padding has to be done on the left-side (optional; default value = true)</param>
         /// <returns>Reprocessed string of given length, according to rules documented in the method description</returns>
         public static string BuildStrictLengthString(string value, int length, char paddingChar, bool padRight = true)
@@ -387,7 +387,7 @@ namespace Commons
         /// <param name="targetLength">Target length of the final string</param>
         /// <param name="paddingByte">Byte to use if padding is needed</param>
         /// <param name="encoding">Encoding to use to represent the given string in binary format</param>
-        /// <param name="padRight">True if the padding has to be done on the right-side of the target string; 
+        /// <param name="padRight">True if the padding has to be done on the right-side of the target string;
         /// false if the padding has to be done on the left-side (optional; default value = true)</param>
         /// <returns>Reprocessed string of given length, in binary format, according to rules documented in the method description</returns>
         public static byte[] BuildStrictLengthStringBytes(string value, int targetLength, byte paddingByte, Encoding encoding, bool padRight = true)
@@ -427,7 +427,7 @@ namespace Commons
         /// Covert given string value to boolean.
         ///   - Returns true if string represents a non-null numeric value or the word "true"
         ///   - Returns false if not
-        ///   
+        ///
         /// NB : This implementation exists because default .NET implementation has a different convention as for parsing numbers
         /// </summary>
         /// <param name="value">Value to be converted</param>
@@ -471,7 +471,7 @@ namespace Commons
         public static byte[] EncodeTo64(byte[] data)
         {
             // Each 3 byte sequence in the source data becomes a 4 byte
-            // sequence in the character array. 
+            // sequence in the character array.
             long arrayLength = (long)(4.0d / 3.0d * data.Length);
 
             // If array length is not divisible by 4, go up to the next
@@ -490,7 +490,7 @@ namespace Commons
 
         /// <summary>
         /// Indicate if the given string is exclusively composed of digital characters
-        /// 
+        ///
         /// NB1 : decimal separators '.' and ',' are tolerated except if allowsOnlyIntegers argument is set to True
         /// NB2 : whitespaces ' ' are not tolerated
         /// NB3 : any alternate notation (e.g. exponent, hex) is not tolerated
@@ -539,24 +539,23 @@ namespace Commons
         {
             if (string.IsNullOrEmpty(s)) return -1;
 
-            bool insideInt = false;
-            StringBuilder sb = new StringBuilder();
-            foreach (var t in s)
+            int startIndex = -1;
+            int i = 0;
+            for (; i < s.Length; i++)
             {
-                if (IsDigit(t))
+                if (IsDigit(s[i]))
                 {
-                    if (!insideInt) insideInt = true;
-                    sb.Append(t);
+                    if (startIndex == -1) startIndex = i;
                 }
                 else
                 {
-                    if (insideInt) break;
+                    if (startIndex != -1) break;
                 }
             }
 
-            if (sb.Length > 0)
+            if (startIndex != -1)
             {
-                long number = long.Parse(sb.ToString());
+                long number = long.Parse(s[startIndex..i]);
                 if (number > int.MaxValue) number = 0;
                 return (int)number;
             }
@@ -634,7 +633,7 @@ namespace Commons
         }
 
         /// <summary>
-        /// Return the human-readable file size for an arbitrary, 64-bit file size 
+        /// Return the human-readable file size for an arbitrary, 64-bit file size
         /// The default format is "0.### XB", e.g. "4.2 KB" or "1.434 GB"
         /// Source : https://www.somacon.com/p576.php
         /// </summary>
@@ -708,8 +707,8 @@ namespace Commons
         }
 
         /// <summary>
-        /// Trace the given Exception 
-        /// - To the ATL logger 
+        /// Trace the given Exception
+        /// - To the ATL logger
         /// - To the Console, if Settings.OutputStacktracesToConsole is true
         /// </summary>
         /// <param name="e">Exception to trace</param>


### PR DESCRIPTION
Replace Contains + IndexOf with just IndexOf
Use Spans when possible
Reduce allocations

Benchmark for the ParseFirstIntegerPart function:
```
| Method | Value        | Mean      | Error     | StdDev    | Gen0   | Allocated |
|------- |------------- |----------:|----------:|----------:|-------:|----------:|
| Old    | 123ABC       | 22.273 ns | 0.3023 ns | 0.2827 ns | 0.0027 |     136 B |
| New    | 123ABC       |  6.807 ns | 0.0055 ns | 0.0051 ns |      - |         - |
| Old    | ABC123       | 22.527 ns | 0.2272 ns | 0.2014 ns | 0.0027 |     136 B |
| New    | ABC123       |  8.188 ns | 0.0332 ns | 0.0294 ns |      - |         - |
| Old    | ABC123ABC    | 23.402 ns | 0.3810 ns | 0.3378 ns | 0.0027 |     136 B |
| New    | ABC123ABC    |  8.631 ns | 0.0224 ns | 0.0210 ns |      - |         - |
| Old    | ABC123ABC123 | 23.827 ns | 0.2125 ns | 0.1988 ns | 0.0027 |     136 B |
| New    | ABC123ABC123 |  8.610 ns | 0.0443 ns | 0.0414 ns |      - |         - |
```