### PR TITLE
Optimize BuildStrictLengthStringBytes

### DIFF
--- a/ATL/AudioData/AudioDataIOFactory.cs
+++ b/ATL/AudioData/AudioDataIOFactory.cs
@@ -78,7 +78,7 @@ namespace ATL.AudioData
         // ------------------------------------------------------------------------------------------
 
         /// <summary>
-        /// Gets the instance of this factory (Singleton pattern) 
+        /// Gets the instance of this factory (Singleton pattern)
         /// </summary>
         /// <returns>Instance of the AudioReaderFactory of the application</returns>
         public static AudioDataIOFactory GetInstance()
@@ -414,8 +414,8 @@ namespace ATL.AudioData
             if (ID3v2.IsValidHeader(data))
             {
                 hasID3v2 = true;
-                byte[] data2 = new byte[4];
-                Array.Copy(data, 6, data2, 0, 4); // bytes 6-9 only
+
+                var data2 = data.AsSpan()[6..10]; // bytes 6-9 only
                 int id3v2Size = StreamUtils.DecodeSynchSafeInt32(data2) + 10;  // 10 being the size of the header
                 s.Seek(id3v2Size, SeekOrigin.Begin);
                 offset = s.Position;

--- a/ATL/AudioData/IO/AA.cs
+++ b/ATL/AudioData/IO/AA.cs
@@ -225,8 +225,8 @@ namespace ATL.AudioData.IO
         // Read header data
         private bool readHeader(BufferedBinaryReader source)
         {
-            byte[] buffer = new byte[8];
-            if (source.Read(buffer, 0, buffer.Length) < buffer.Length) return false;
+            Span<byte> buffer = stackalloc byte[8];
+            if (source.Read(buffer) < buffer.Length) return false;
             if (!IsValidHeader(buffer)) return false;
 
             uint fileSize = BinaryPrimitives.ReadUInt32BigEndian(buffer);
@@ -446,7 +446,7 @@ namespace ATL.AudioData.IO
         private int writeCoreToc(Stream s)
         {
             s.Seek(tocOffset, SeekOrigin.Begin);
-            var span = new Span<byte>(new byte[4]);
+            Span<byte> span = stackalloc byte[4];
             BufferedBinaryReader br = new BufferedBinaryReader(s);
 
             IDictionary<int, TocEntry> newToc = readToc(br);

--- a/ATL/AudioData/IO/AAC.cs
+++ b/ATL/AudioData/IO/AAC.cs
@@ -165,10 +165,10 @@ namespace ATL.AudioData.IO
         // Get header type of the file
         private byte recognizeHeaderType(Stream source)
         {
-            byte[] header = new byte[4];
+            Span<byte> header = stackalloc byte[4];
 
             source.Seek(sizeInfo.ID3v2Size, SeekOrigin.Begin);
-            if (source.Read(header, 0, header.Length) < header.Length) return AAC_HEADER_TYPE_UNKNOWN;
+            if (source.Read(header) < header.Length) return AAC_HEADER_TYPE_UNKNOWN;
 
             byte result = recognizeHeaderType(header);
             if (result != AAC_BITRATE_TYPE_UNKNOWN)

--- a/ATL/AudioData/IO/AIFF.cs
+++ b/ATL/AudioData/IO/AIFF.cs
@@ -195,16 +195,16 @@ namespace ATL.AudioData.IO
         private ChunkHeader seekNextChunkHeader(BufferedBinaryReader source, long limit, string previousChunkId)
         {
             ChunkHeader header = new ChunkHeader();
-            byte[] aByte = new byte[1];
+            Span<byte> aByte = stackalloc byte[1];
             int previousChunkSizeCorrection = 0;
 
-            if (source.Read(aByte, 0, 1) < 1) return header;
+            if (source.Read(aByte) < 1) return header;
 
             // In case previous chunk has a padding byte, seek a suitable first character for an ID
             if (aByte[0] != 40 && !char.IsLetter((char)aByte[0]) && source.Position <= limit)
             {
                 previousChunkSizeCorrection++;
-                if (source.Position < limit && source.Read(aByte, 0, 1) < 1) return header;
+                if (source.Position < limit && source.Read(aByte) < 1) return header;
             }
 
             // Update zone size (remove and replace zone with updated size)

--- a/ATL/AudioData/IO/FLAC.cs
+++ b/ATL/AudioData/IO/FLAC.cs
@@ -181,7 +181,7 @@ namespace ATL.AudioData.IO
             source.Seek(sizeInfo.ID3v2Size, SeekOrigin.Begin);
             header = ReadHeader(source);
 
-            // Process data if loaded and header valid    
+            // Process data if loaded and header valid
             if (header.IsValid())
             {
                 ChannelsArrangement = header.getChannelsArrangement();
@@ -199,11 +199,11 @@ namespace ATL.AudioData.IO
                         blockEndOffset = source.Position;
                     }
 
-                    byte[] metaDataBlockHeader = new byte[4];
+                    Span<byte> metaDataBlockHeader = stackalloc byte[4];
                     bool isLast;
                     do // Read all metadata blocks
                     {
-                        if (source.Read(metaDataBlockHeader, 0, 4) < 4) return false;
+                        if (source.Read(metaDataBlockHeader) < 4) return false;
                         isLast = (metaDataBlockHeader[0] & FLAG_LAST_METADATA_BLOCK) > 0; // last flag ( first bit == 1 )
 
                         blockIndex++;

--- a/ATL/AudioData/IO/ID3v1.cs
+++ b/ATL/AudioData/IO/ID3v1.cs
@@ -287,7 +287,6 @@ namespace ATL.AudioData.IO
             string header = Utils.Latin1Encoding.GetString(data, 0, 3);
             if (!header.Equals(ID3V1_ID)) return false;
 
-            byte[] endComment = new byte[2];
             structureHelper.AddZone(source.Position - ID3V1_TAG_SIZE, ID3V1_TAG_SIZE);
 
             setMetaField(Field.TITLE, Utils.Latin1Encoding.GetString(data, 3, 30).Replace("\0", ""));
@@ -296,13 +295,13 @@ namespace ATL.AudioData.IO
             setMetaField(Field.RECORDING_YEAR, Utils.Latin1Encoding.GetString(data, 93, 4).Replace("\0", ""));
             string comment = Utils.Latin1Encoding.GetString(data, 97, 28).Replace("\0", "");
 
-            Array.Copy(data, 125, endComment, 0, 2);
+            var endComment = data.AsSpan(125, 2);
             m_tagVersion = GetTagVersion(endComment);
 
             // Fill properties using tag data
             if (TAG_VERSION_1_0 == m_tagVersion)
             {
-                comment += Utils.Latin1Encoding.GetString(endComment, 0, 2).Replace("\0", "");
+                comment += Utils.Latin1Encoding.GetString(endComment).Replace("\0", "");
             }
             else
             {
@@ -315,7 +314,7 @@ namespace ATL.AudioData.IO
             return true;
         }
 
-        private static byte GetTagVersion(byte[] endComment)
+        private static byte GetTagVersion(ReadOnlySpan<byte> endComment)
         {
             byte result = TAG_VERSION_1_0;
             // Terms for ID3v1.1

--- a/ATL/AudioData/IO/ID3v2.cs
+++ b/ATL/AudioData/IO/ID3v2.cs
@@ -2197,9 +2197,9 @@ namespace ATL.AudioData.IO
             result.Size = 1;
             result.Encoding = Encoding.Unicode;
 
-            byte[] b = new byte[1];
+            Span<byte> b = stackalloc byte[1];
 
-            if (source.Read(b, 0, 1) < 1) return result;
+            if (source.Read(b) < 1) return result;
             bool first = true;
             bool foundFE = false;
             bool foundFF = false;
@@ -2225,7 +2225,7 @@ namespace ATL.AudioData.IO
                     first = false;
                 }
 
-                if (source.Read(b, 0, 1) < 1) return result;
+                if (source.Read(b) < 1) return result;
                 result.Size++;
             }
 

--- a/ATL/Utils/StreamUtils.cs
+++ b/ATL/Utils/StreamUtils.cs
@@ -63,7 +63,7 @@ namespace ATL
         /// <param name="data">Array of bytes to read value from</param>
         /// <param name="offset">Offset to read value from (default : 0)</param>
         /// <returns>Decoded value</returns>
-        public static uint DecodeBEUInt24(byte[] data, int offset = 0)
+        public static uint DecodeBEUInt24(ReadOnlySpan<byte> data, int offset = 0)
         {
             if (data.Length - offset < 3) throw new InvalidDataException($"Value should at least contain 3 bytes after offset; actual size={data.Length - offset} bytes");
             return (uint)(data[offset] << 16 | data[offset + 1] << 8 | data[offset + 2]);
@@ -306,7 +306,7 @@ namespace ATL
         /// </summary>
         /// <param name="data">4-byte array containing to convert</param>
         /// <returns>Decoded Int32</returns>
-        public static int DecodeSynchSafeInt32(byte[] data)
+        public static int DecodeSynchSafeInt32(ReadOnlySpan<byte> data)
         {
             if (data.Length < 4) throw new ArgumentException($"Array length has to be at least 4 bytes; found : {data.Length} bytes");
 


### PR DESCRIPTION
Reduces the number of allocations in BuildStrictLengthStringBytes
Use stackalloc in more places