### PR TITLE
Bump GitHub Actions to use latest versions

### DIFF
--- a/.github/workflows/nuget_build_release.yml
+++ b/.github/workflows/nuget_build_release.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: "Install Dotnet"
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 


### PR DESCRIPTION
Hi, since I'm the one who origially proposed and made the build workflow, I figured I would migrate your workflow actions to a newer version since Github annonced the deprecation of Node 20  (which was previously used by their actions).

You can learn more here : https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

You can seem most of Github updates on their blog at : https://github.blog/changelog/

Actions are github repos, if you want to check their changelogs you can go to :
- https://github.com/actions/setup-dotnet
- https://github.com/actions/checkout