### PR TITLE
Fix negative duration on non-fragmented M4A files with moof atom

### DIFF
--- a/ATL/AudioData/IO/MP4.cs
+++ b/ATL/AudioData/IO/MP4.cs
@@ -692,7 +692,7 @@ namespace ATL.AudioData.IO
                 moofSize = navigateToAtom(s, "moof");
             }
 
-            if (isFragmented)
+            if (isFragmented && durationAll > 0)
             {
                 calculatedDurationMs = durationAll * 1000.0 / SampleRate;
                 bitrate = (int)Math.Round(mdatSizeAll * 8 / calculatedDurationMs * 1000.0, 0);


### PR DESCRIPTION
## Description
This PR fixes an issue where `readMoof` incorrectly calculates a large negative duration for **valid non-fragmented M4A files** that contain a small `moof` atom.

## Root cause
- Some non-fragmented M4A files contain a small `moof` atom (e.g. 288 bytes) without valid fragment data.
- These files are **not real fragmented MP4s**: they contain `moov` sample tables and a correct `mvhd` duration.
- `readMoof` previously assumed any file with a `moof` atom was fragmented.
- When `traf` exists but `trun` contains no valid samples, `durationAll` becomes negative due to invalid data.
- This negative value overwrites the correct duration parsed earlier from `mvhd`.

FFmpeg correctly reports the duration from `mvhd` and does not treat these files as fragmented.

## Fix
Guard the fragmented duration calculation with a positivity check:
```csharp
if (isFragmented && durationAll > 0)
{
calculatedDurationMs = durationAll * 1000.0 / SampleRate;
bitrate = (int)Math.Round(mdatSizeAll * 8 / calculatedDurationMs * 1000.0, 0);
AudioDataSize = mdatSizeAll;
}
```

## Sample file
[files.zip](https://github.com/user-attachments/files/27903734/files.zip)
FFprobe trace output & ATL.Track values (see track_debug_info.txt) are also contained.

Key output:
```
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] type:'stts' parent:'stbl' sz: 16 114 174
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] track[0].stts.entries = 0
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] type:'stsc' parent:'stbl' sz: 16 130 174
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] track[0].stsc.entries = 0
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] type:'stsz' parent:'stbl' sz: 20 146 174
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] sample_size = 0 sample_count = 0
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] type:'stco' parent:'stbl' sz: 16 166 174
...
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] stream 0: start_time: 0 duration: 127.869333
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] stream 1: start_time: 0 duration: 127.869333
[mov,mp4,m4a,3gp,3g2,mj2 @ 00000245c36ff7c0] format: start_time: 0 duration: 127.869333 (estimate from stream) bitrate=265 kb/s
```